### PR TITLE
Fixes for julia 0.7 and 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
+  - 1.0
   - nightly
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Gettext"); Pkg.test("Gettext"; coverage=true)'
+  - julia --check-bounds=yes -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("Gettext"); Pkg.test("Gettext"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Gettext")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'import Pkg; cd(joinpath(dirname(pathof(Gettext)), "..")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-PyCall 0.5
+julia 0.7
+PyCall

--- a/src/Gettext.jl
+++ b/src/Gettext.jl
@@ -2,15 +2,19 @@ module Gettext
 
 using PyCall
 
-@pyimport gettext as gt
+const gt = PyNULL()
 
-bindtextdomain(domain, localedir=nothing) = gt.bindtextdomain(domain, localedir)
-textdomain(domain=nothing) = gt.textdomain(domain)
+function __init__()
+    copy!(gt, pyimport("gettext"))
+end
 
-gettext(message) = gt.gettext(message)
-dgettext(domain, message) = gt.dgettext(domain, message)
-ngettext(singular, plural, n) = gt.ngettext(singular, plural, n)
-dngettext(domain, singular, plural, n) = gt.dngettext(domain, singular, plural, n)
+bindtextdomain(domain, localedir=nothing) = gt[:bindtextdomain](domain, localedir)
+textdomain(domain=nothing) = gt[:textdomain](domain)
+
+gettext(message) = gt[:gettext](message)
+dgettext(domain, message) = gt[:dgettext](domain, message)
+ngettext(singular, plural, n) = gt[:ngettext](singular, plural, n)
+dngettext(domain, singular, plural, n) = gt[:dngettext](domain, singular, plural, n)
 
 macro __str(s)
     gettext(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,12 @@ old_language = get(ENV, "LANGUAGE", nothing)
 ENV["LANGUAGE"] = "fr"
 
 using Gettext
-using Base.Test
+using Test
 using Formatting
+import Pkg
 
 # Set up gettext
-trdir = realpath(joinpath(Pkg.dir("Gettext"), "po"))
+trdir = realpath(joinpath(dirname(pathof(Gettext)), "..", "po"))
 @test isfile(joinpath(trdir, "fr", "LC_MESSAGES", "sample.mo"))
 bindtextdomain("sample", trdir)
 textdomain("sample")


### PR DESCRIPTION
Now supports precompilation (which is the default on 0.7 and higher)