### PR TITLE
unescape _"..." strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ In fact, such a sample program can be run from the toplevel directory of this re
     $ LANGUAGE=fr julia helloworld.jl
     Bonjour le monde !
 
+Note that Julia's standard backslash-escapes (like `\n` for newline or `\uXXXX` for U+XXXX) *are* supported in `_"..."` strings, but `$` interpolation is *not* supported.  The reason for the latter
+is that translated strings should generally not depend on runtime values, though for the rare exceptions
+you can call `gettext("...")` with an ordinary Julia string.  To substitute numerical quantities with
+singular and plural forms, see below.
+
 ## Singular/plural interpolation
 
 Gettext allows you to look up singular and plural forms of a string depending upon a runtime integer, using the `ngettext` function.

--- a/src/Gettext.jl
+++ b/src/Gettext.jl
@@ -62,11 +62,11 @@ function npgettext(domain::AbstractString, context::AbstractString, msgid::Abstr
 end
 
 macro __str(s)
-    :(gettext($(esc(s))))
+    :(gettext($(esc(unescape_string(s)))))
 end
 
 macro N__str(s)
-    :($(esc(s)))
+    :($(esc(unescape_string(s))))
 end
 
 export bindtextdomain, textdomain, gettext, pgettext, ngettext, npgettext, @__str, @N__str

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,8 +37,8 @@ try
 
     @testset "basic tests" begin
         # Test basic macros
-        @test _"Hello, world!" == "Bonjour le monde !"
-        @test N_"Hello, world!" == "Hello, world!"
+        @test _"H\u0065llo, world!" == "Bonjour le monde !"
+        @test N_"H\u0065llo, world!" == "Hello, world!"
 
         @test _"Unknown key" == "Unknown key"
 


### PR DESCRIPTION
Unescapes `_"..."` and `N_"..."` string macros, so that the strings can contain things like `\n` or `\uXXXX` just like ordinary Julia strings.

However, do *not* handle `$` interpolation — we leave `$` values as-is, because translation keys should not generally depend upon runtime values.

Closes #8.