### PR TITLE
pass abspath to bindtextdomain

### DIFF
--- a/src/Gettext.jl
+++ b/src/Gettext.jl
@@ -19,15 +19,16 @@ function bindtextdomain(domain::AbstractString)
 end
 
 function bindtextdomain(domain::AbstractString, dir_name::AbstractString)
-    # bintextdomain(domain, dir_name) returns the dir_name as a string, but
-    # you are required to not free the result.  Might as well ignore it.
+    abs_dir_name = abspath(dir_name) # gettext recommends against relative paths for bindtextdomain
     @static if Sys.iswindows()
-        ccall((:libintl_wbindtextdomain,libintl), Cwstring, (Cstring,Cwstring), domain, dir_name)
+        ccall((:libintl_wbindtextdomain,libintl), Cwstring, (Cstring,Cwstring), domain, abs_dir_name)
     else
-        ccall((:libintl_bindtextdomain,libintl), Cstring, (Cstring,Cstring), domain, dir_name)
+        ccall((:libintl_bindtextdomain,libintl), Cstring, (Cstring,Cstring), domain, abs_dir_name)
     end
     ccall((:libintl_bind_textdomain_codeset,libintl), Cstring, (Cstring,Cstring), domain, "UTF-8")
-    return dir_name
+    # bintextdomain(domain, dir_name) returns the dir_name as a string, but
+    # you are required to not free the result.  Might as well ignore it.
+    return abs_dir_name
 end
 
 gettext(msgid::AbstractString) = unsafe_string(ccall((:libintl_gettext,libintl), Cstring, (Cstring,), msgid))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ try
         @test isfile(joinpath(trdir, "fr", "LC_MESSAGES", "sample.mo"))
         bindtextdomain("sample", trdir)
         textdomain("sample")
-        @test bindtextdomain("sample") == trdir
+        @test bindtextdomain("sample") == abspath(trdir)
         @test textdomain() == "sample"
     end
 


### PR DESCRIPTION
The gettext manual says:
> It is important to remember that relative path names for the `dir_name` parameter can be trouble. Since the path is always computed relative to the current directory different results will be achieved when the program executes a `chdir` command. Relative paths should always be avoided to avoid dependencies and unreliabilities. 

So, it seems safer to call `abspath` on the directory before passing it to `bindtextdomain`.